### PR TITLE
mycourses_exporter.py: remove assignment that have no name

### DIFF
--- a/user-scripts/mycourses_exporter.py
+++ b/user-scripts/mycourses_exporter.py
@@ -69,6 +69,7 @@ class MyCoursesExportPlugin(ExportPlugin):
         # Generete a format string for each row entry
         keys = ['username']
         keys.extend(list(map(lambda a : a.name, gradebook.assignments)))
+        keys = [ x for x in keys if x ]  # Remove empty keys
         fh.write(",".join(keys) + "\n")
         fmt = ",".join(["{" + x + "}" for x in keys]) + "\n"
 


### PR DESCRIPTION
- Remove assignments that have no name.  This leads to an error later,
  and in the past it seems this was caused by a bad unnamed (and not
  visible) assignment in the database.