### PR TITLE
jupyterhub_config: Fix condition for datadir read/write

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -685,10 +685,14 @@ async def pre_spawn_hook(spawner: KubeSpawner):
                 spawner.volume_mounts.append({"mountPath": "/coursedata",
                                             "subPath": "course/{}/data/".format(course_slug),
                                             "name": "jupyter-nfs",
-                                            "readOnly": ((not is_instructor)
-                                                        and not course_data.get('datadir_readwrite', False)
-                                                        and not getattr(spawner, 'as_instructor', False)
-                                                        ),
+                                            "readOnly": not ( # condition for read-write
+                                                              ( # condition for 'as an instructor'
+                                                                is_instructor
+                                                                and getattr(spawner, 'as_instructor', False)
+                                                              )
+                                                              # datadir_rw makes it always read-write
+                                                              or course_data.get('datadir_readwrite', False)
+                                                            )
                                             })
                 environ['COURSEDATA'] = '/coursedata/'
 


### PR DESCRIPTION
- Problem: An instructor reported that starting as a student would
  still put the datadir in read-write mode.  This wasn't good, since
  they can't test the effect of a read-only data dir that students
  would get.
- I think there was a problem in the condation, but anyway it was very
  hard to understand what was happening here.  I re-factored the test
  while trying to fix it.
- New test is not (conditions_for_readwrite).  The test both confirms
  the instructor status (not just the as_instructor profile list
  property) and also if datadir_readwrite means "always read-write,
  even for students"
- Review: detailed read to see if the conditions are correct.